### PR TITLE
Make mantis plugin compatible with gradle 8.0

### DIFF
--- a/src/main/groovy/io/mantisrx/mantisplugin/MantisPlugin.groovy
+++ b/src/main/groovy/io/mantisrx/mantisplugin/MantisPlugin.groovy
@@ -70,7 +70,7 @@ class MantisPlugin implements Plugin<Project> {
                     readyForJobMaster = true
                 }
                 args = [project.distZip.archivePath,
-                        project.distZip.baseName,
+                        project.distZip.archiveBaseName,
                         project.version,
                         project.distZip.destinationDir,
                         readyForJobMaster]


### PR DESCRIPTION
### Context

Explain context and other details for this pull request.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
- [ ] Added copyright headers for new files from `CONTRIBUTING.md`
