### PR TITLE
Add dependency declaration to sourcesJar task

### DIFF
--- a/src/main/groovy/io/mantisrx/mantisplugin/MantisPlugin.groovy
+++ b/src/main/groovy/io/mantisrx/mantisplugin/MantisPlugin.groovy
@@ -42,9 +42,13 @@ class MantisPlugin implements Plugin<Project> {
             project.mainClassName = 'io.mantisrx.runtime.command.LoadValidateCreateZip'
         }
 
-        project.task("copyMantisJobProvider") {
+        def copyMantisJobProvider = project.task("copyMantisJobProvider") {
             def config = new File("src/main/resources/META-INF/services")
             outputs.dir config
+        }
+
+        project.tasks.named('sourcesJar').configure {
+            it.dependsOn(copyMantisJobProvider)
         }
 
         project.applicationDistribution.from(project.tasks.copyMantisJobProvider) {


### PR DESCRIPTION
### Context

This is to fix the error in gradle 8.+ where sourcesJar needs to declare dep to copyMantisJobProvider.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
- [ ] Added copyright headers for new files from `CONTRIBUTING.md`
